### PR TITLE
Change check in updateConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,19 +32,19 @@ function instance(system, id, config) {
 
 instance.prototype.updateConfig = function (config) {
 	var self = this;
-	self.init_presets();
+	var resetConnection = false;
 
-	if (self.socket !== undefined) {
-		self.socket.destroy();
-		delete self.socket;
-	}
-	if (self.heartbeat) {
-		clearInterval(self.heartbeat);
-		delete self.heartbeat;
+	if (self.config.host != config.host || self.config.port != config.port) {
+		resetConnection = true;
 	}
 
 	self.config = config;
-	self.init_tcp();
+
+	self.init_presets();
+
+	if (resetConnection === true || self.socket === undefined) {
+		self.init_tcp();
+	}
 };
 
 instance.prototype.init = function () {
@@ -70,17 +70,18 @@ instance.prototype.init_tcp = function () {
 	var self = this;
 
 	if (self.socket !== undefined) {
-		if (self.heartbeat) {
-			clearInterval(self.heartbeat);
-			delete self.heartbeat;
-		}
 		self.socket.destroy();
 		delete self.socket;
 	}
 
+	if (self.heartbeat) {
+		clearInterval(self.heartbeat);
+		delete self.heartbeat;
+	}
+
 	self.status(self.STATE_WARNING, 'Connecting');
 
-	if (self.config.host) {
+	if (self.config.host && self.config.port) {
 		self.socket = new tcp(self.config.host, self.config.port);
 
 		self.socket.on('end', function() {


### PR DESCRIPTION
@istnv this is what I mean.  It actually prevents extra calls to `init_tcp()` when the IP and port don't change so long as the socket already exists.